### PR TITLE
Add `stringName` for ServerPlayer

### DIFF
--- a/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/UniversalHelper.kt
+++ b/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/UniversalHelper.kt
@@ -60,6 +60,8 @@ fun ServerPlayer.addStage(stage: String) = GameStageHelper.addStage(this, stage)
 fun ServerPlayer.removeStage(stage: String) = GameStageHelper.removeStage(this, stage)
 val ServerPlayer.stages get() = GameStageHelper.getPlayerData(this)?.stages ?: emptyList()
 
+val ServerPlayer.stringName: String get() = this.displayName.string
+
 fun StoryStateMachine.test() {
     val players by server.players.filter { it.hasStage("progressable") }
 


### PR DESCRIPTION
Поясняю, почему это нужно:
KSFF почему-то багуется, и не хочет компилировать какие-либо классы, находящиеся в `com.mojang`, от чего тот выдает ошибку (см скрин ниже). Поэтому, я добавил эту переменную для того, чтобы избежать использование классов пакета  `com.mojang`.
![image](https://github.com/HollowHorizon/HollowEngine/assets/46783751/a3a8c25b-32d8-48a7-8dc3-b960d4725d5f)
