### PR TITLE
clean up dialogue classes without breaking changes

### DIFF
--- a/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/npcs/dialogues/Dialogue.kt
+++ b/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/npcs/dialogues/Dialogue.kt
@@ -22,7 +22,10 @@ import ru.hollowhorizon.hollowengine.common.utils.nbt.ForItemStack
 
 @Serializable
 @HollowPacketHandler(HollowPacketHandler.Direction.TO_SERVER)
-class DialogueUpdateEvent(val tag: @Serializable(ForCompoundNBT::class) CompoundTag) : HollowPacket, Event {
+class DialogueUpdateEvent(
+    val tag: @Serializable(ForCompoundNBT::class) CompoundTag
+) : HollowPacket, Event {
+
     override fun handle(player: Player) {
         EventBus.post(this)
     }
@@ -30,36 +33,77 @@ class DialogueUpdateEvent(val tag: @Serializable(ForCompoundNBT::class) Compound
 
 interface DialogChoice {
     val content: String
-    fun UiScope.icon(scale: Float, progress: Float)
+
+    fun UiScope.buildIcon(scale: Float, progress: Float)
 
     companion object {
-        fun simple(text: String, icon: String = "hollowengine:textures/gui/dialogues/simple.png") =
-            ChoiceIcon(text, icon)
+        private const val DEFAULT_ICON_PATH = "hollowengine:textures/gui/dialogues/simple.png"
 
-        fun item(text: String, item: ItemStack) = ChoiceItem(text, item)
+        fun simple(text: String, iconPath: String = DEFAULT_ICON_PATH): DialogChoice =
+            ChoiceIcon(text, iconPath)
+
+        fun item(text: String, itemStack: ItemStack): DialogChoice =
+            ChoiceItem(text, itemStack)
     }
 }
 
 @Serializable
 @Polymorphic(DialogChoice::class)
-class ChoiceIcon(override val content: String, val icon: String) : DialogChoice {
-    override fun UiScope.icon(scale: Float, progress: Float) {
-        Image(icon) {
-            modifier.size(18.dp * scale, 18.dp * scale)
-                .margin(top = 4.dp * scale, start = 2.dp * scale)
-                .tint(Color(1f, 1f, 1f, Interpolation.QUAD_IN(progress)))
+class ChoiceIcon(
+    override val content: String,
+    val iconPath: String
+) : DialogChoice {
+
+    companion object {
+        private const val ICON_SIZE_DP = 18f
+        private const val ICON_MARGIN_TOP_DP = 4f
+        private const val ICON_MARGIN_START_DP = 2f
+        private val FULL_WHITE = Color(1f, 1f, 1f, 1f)
+    }
+
+    override fun UiScope.buildIcon(scale: Float, progress: Float) {
+        val tintColor = FULL_WHITE.withAlpha(Interpolation.QUAD_IN(progress))
+
+        Image(iconPath) {
+            modifier
+                .size(ICON_SIZE_DP.dp * scale, ICON_SIZE_DP.dp * scale)
+                .margin(
+                    top = ICON_MARGIN_TOP_DP.dp * scale,
+                    start = ICON_MARGIN_START_DP.dp * scale
+                )
+                .tint(tintColor)
         }
     }
 }
 
 @Serializable
 @Polymorphic(DialogChoice::class)
-class ChoiceItem(override val content: String, val item: @Serializable(ForItemStack::class) ItemStack) : DialogChoice {
-    override fun UiScope.icon(scale: Float, progress: Float) {
-        Item(item) {
-            modifier.size(18.dp * scale, 18.dp * scale)
-                .margin(top = 4.dp * scale, start = 2.dp * scale)
-                .tint(Color(1f, 1f, 1f, Interpolation.QUAD_IN(progress)))
+class ChoiceItem(
+    override val content: String,
+    val itemStack: @Serializable(ForItemStack::class) ItemStack
+) : DialogChoice {
+
+    companion object {
+        private const val ICON_SIZE_DP = 18f
+        private const val ICON_MARGIN_TOP_DP = 4f
+        private const val ICON_MARGIN_START_DP = 2f
+        private val FULL_WHITE = Color(1f, 1f, 1f, 1f)
+    }
+
+    override fun UiScope.buildIcon(scale: Float, progress: Float) {
+        val tintColor = FULL_WHITE.withAlpha(Interpolation.QUAD_IN(progress))
+
+        Item(itemStack) {
+            modifier
+                .size(ICON_SIZE_DP.dp * scale, ICON_SIZE_DP.dp * scale)
+                .margin(
+                    top = ICON_MARGIN_TOP_DP.dp * scale,
+                    start = ICON_MARGIN_START_DP.dp * scale
+                )
+                .tint(tintColor)
         }
     }
 }
+
+private fun Color.withAlpha(alpha: Float): Color =
+    Color(r, g, b, this.a * alpha)

--- a/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/npcs/dialogues/DialogueScene.kt
+++ b/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/npcs/dialogues/DialogueScene.kt
@@ -15,8 +15,8 @@ class DialogueScene {
     var character = ""
     var text = ""
 
-    val characters = mutableSetOf<@Serializable(ForEntity::class) Entity>()
-    val choices = mutableListOf<DialogChoice>()
+    val characters: MutableSet<@Serializable(ForEntity::class) Entity> = mutableSetOf()
+    val choices: MutableList<DialogChoice> = mutableListOf()
 
     fun sync(vararg players: ServerPlayer) {
         UpdateScenePacket(this).send(*players)
@@ -25,11 +25,25 @@ class DialogueScene {
 
 @Serializable
 @HollowPacketHandler(HollowPacketHandler.Direction.TO_CLIENT)
-class UpdateScenePacket(val scene: DialogueScene) : HollowPacket {
-    override fun handle(player: Player) {
-        val screen = Minecraft.getInstance().screen as? DialogGui ?: DialogGui().apply { Minecraft.getInstance().setScreen(this) }
+class UpdateScenePacket(
+    val scene: DialogueScene
+) : HollowPacket {
 
-        screen.update(scene)
+    companion object {
+        private const val LATE_INIT_ERROR = "Minecraft instance is not available"
+    }
+
+    override fun handle(player: Player) {
+        val minecraft = Minecraft.getInstance()
+        val dialogGui = when (val currentScreen = minecraft.screen) {
+            is DialogGui -> currentScreen
+            else -> {
+                val newGui = DialogGui()
+                minecraft.setScreen(newGui)
+                newGui
+            }
+        }
+
+        dialogGui.update(scene)
     }
 }
-


### PR DESCRIPTION
Extracted magic numbers into named constant, improve var names for clarity (icon -> buildIcon, item -> itemStack), added explicit type arguments for collections, and simplified screen handling in packet