### PR TITLE
Export Katari bindings to JSON into root engine folder

### DIFF
--- a/katari-binding-processor/src/main/kotlin/ru/hollowhorizon/hollowengine/katari/processor/KatariBindingProcessorProvider.kt
+++ b/katari-binding-processor/src/main/kotlin/ru/hollowhorizon/hollowengine/katari/processor/KatariBindingProcessorProvider.kt
@@ -487,6 +487,16 @@ private class KatariBindingProcessor(
         OutputStreamWriter(file, Charsets.UTF_8).use { writer ->
             writer.write(KatariBindingCodegen(scriptTypes, functions, classes, properties, enumTypes).generate())
         }
+
+        val jsonFile = codeGenerator.createNewFile(
+            Dependencies(aggregating = true, sources = sources),
+            "",
+            "katari-bindings",
+            extensionName = "json",
+        )
+        OutputStreamWriter(jsonFile, Charsets.UTF_8).use { writer ->
+            writer.write(KatariBindingsJsonGen(scriptTypes, functions, classes, properties).generate())
+        }
     }
 
     private fun KSAnnotated.hasAnnotation(name: String): Boolean {

--- a/katari-binding-processor/src/main/kotlin/ru/hollowhorizon/hollowengine/katari/processor/KatariBindingsJsonGen.kt
+++ b/katari-binding-processor/src/main/kotlin/ru/hollowhorizon/hollowengine/katari/processor/KatariBindingsJsonGen.kt
@@ -1,0 +1,96 @@
+package ru.hollowhorizon.hollowengine.katari.processor
+
+internal class KatariBindingsJsonGen(
+    private val scriptTypes: List<ScriptTypeModel>,
+    private val functions: List<FunctionModel>,
+    private val classes: List<ClassModel>,
+    private val properties: List<PropertyModel>,
+) {
+    fun generate(): String = buildString {
+        appendLine("{")
+        appendLine("  \"globals\": {")
+        appendLine("    \"functions\": [")
+        val globalFunctions = functions.filter { it.receiver == null }
+        globalFunctions.forEachIndexed { i, f ->
+            appendFunction(f, indent = "      ")
+            if (i < globalFunctions.lastIndex) append(",")
+            appendLine()
+        }
+        appendLine("    ],")
+        appendLine("    \"properties\": [")
+        val globalProps = properties.filter { true } // top-level extension properties
+        globalProps.forEachIndexed { i, p ->
+            appendProperty(p, indent = "      ")
+            if (i < globalProps.lastIndex) append(",")
+            appendLine()
+        }
+        appendLine("    ]")
+        appendLine("  },")
+        appendLine("  \"types\": {")
+
+        // собираем всё по типам
+        val typeMap = mutableMapOf<String, MutableList<Any>>()
+        functions.filter { it.receiver != null }.forEach { f ->
+            typeMap.getOrPut(f.receiver!!.hostTypeId ?: "Unknown") { mutableListOf() }.add(f)
+        }
+        classes.forEach { cls ->
+            val id = cls.type.typeId
+            typeMap.getOrPut(id) { mutableListOf() }.addAll(cls.functions)
+            typeMap.getOrPut(id) { mutableListOf() }.addAll(cls.constructors)
+            typeMap.getOrPut(id) { mutableListOf() }.addAll(cls.properties)
+        }
+        properties.forEach { p ->
+            typeMap.getOrPut(p.receiver.hostTypeId ?: "Unknown") { mutableListOf() }.add(p)
+        }
+
+        val typeEntries = typeMap.entries.toList()
+        typeEntries.forEachIndexed { ti, (typeId, items) ->
+            appendLine("    \"$typeId\": {")
+            appendLine("      \"id\": \"$typeId\",")
+
+            val typeFunctions = items.filterIsInstance<FunctionModel>()
+            val typeProperties = items.filterIsInstance<PropertyModel>()
+
+            appendLine("      \"functions\": [")
+            typeFunctions.forEachIndexed { i, f ->
+                appendFunction(f, indent = "        ")
+                if (i < typeFunctions.lastIndex) append(",")
+                appendLine()
+            }
+            appendLine("      ],")
+            appendLine("      \"properties\": [")
+            typeProperties.forEachIndexed { i, p ->
+                appendProperty(p, indent = "        ")
+                if (i < typeProperties.lastIndex) append(",")
+                appendLine()
+            }
+            appendLine("      ]")
+            append("    }")
+            if (ti < typeEntries.lastIndex) append(",")
+            appendLine()
+        }
+
+        appendLine("  }")
+        append("}")
+    }
+
+    private fun StringBuilder.appendFunction(f: FunctionModel, indent: String) {
+        append("$indent{")
+        append("\"name\": \"${f.scriptName}\", ")
+        append("\"suspend\": ${f.isSuspend}, ")
+        append("\"returns\": \"${f.returnType.kotlinType.substringAfterLast('.')}\", ")
+        append("\"params\": [")
+        f.parameters.forEachIndexed { i, p ->
+            append("{\"name\": \"${p.name}\", \"type\": \"${p.type.kotlinType.substringAfterLast('.')}\", \"optional\": ${p.hasDefault}}")
+            if (i < f.parameters.lastIndex) append(", ")
+        }
+        append("]}")
+    }
+
+    private fun StringBuilder.appendProperty(p: PropertyModel, indent: String) {
+        append("$indent{")
+        append("\"name\": \"${p.scriptName}\", ")
+        append("\"type\": \"${p.valueType.kotlinType.substringAfterLast('.')}\", ")
+        append("\"mutable\": ${p.writable}}")
+    }
+}

--- a/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/katari/HollowEditorAPI.kt
+++ b/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/katari/HollowEditorAPI.kt
@@ -1,0 +1,30 @@
+package ru.hollowhorizon.hollowengine.common.scripting.katari
+
+import org.slf4j.LoggerFactory
+import ru.hollowhorizon.hollowengine.common.files.DirectoryManager
+
+object HollowEditorAPI {
+    private val LOGGER = LoggerFactory.getLogger("HollowEditorAPI")
+
+    fun generate() {
+        val outputFile = DirectoryManager.HOLLOW_ENGINE
+            .resolve("node-editor")
+            .resolve("bindings.json")
+            .toFile()
+
+        if (outputFile.exists()) return
+
+        val json = HollowEditorAPI::class.java
+            .getResourceAsStream("/katari-bindings.json")
+            ?.readBytes()
+            ?.decodeToString()
+            ?: run {
+                LOGGER.error("katari-bindings.json not found in jar")
+                return
+            }
+
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(json)
+        LOGGER.info("Node editor bindings saved → ${outputFile.absolutePath}")
+    }
+}

--- a/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/katari/KatariScriptSystem.kt
+++ b/runtime/src/main/java/ru/hollowhorizon/hollowengine/common/scripting/katari/KatariScriptSystem.kt
@@ -23,6 +23,9 @@ class KatariScriptSystem(
     private val scope: CoroutineScope,
     private val onDirty: () -> Unit,
 ) {
+    init {
+        HollowEditorAPI.generate()
+    }
     private val records = linkedMapOf<String, KatariRunRecord>()
     private val programCache = linkedMapOf<ProgramKey, com.sunnychung.lib.multiplatform.kotlite.katari.KatariProgram>()
 
@@ -30,6 +33,7 @@ class KatariScriptSystem(
         val source = loadSource(path)
         val runId = UUID.randomUUID().toString()
         val (bindings, host) = createHollowKatariBindings(server, runId, sourcePlayer, ::markDirty)
+
         val program = programCache.getOrPut(ProgramKey(source.path, source.hash)) {
             KatariNarrativeProgram(source.path, source.text, bindings)
         }


### PR DESCRIPTION
Adds automatic export of Katari script bindings to `.minecraft/hollowengine/node-editor/bindings.json` on server startup (or world loading in singleplayer)

The KSP processor now generates `katari-bindings.json` alongside the existing Kotlin codegen, containing a structured description of all functions, properties and types available in Katari scripts. On server start, `HollowEditorAPI` copies it from the jar to the game directory.

This allows any external tool to get a complete, always up-to-date description of the Katari API without depending on mod internals or reflection.

In the future, it is planned to expand the HollowEditorAPI to also cover the Enum and describe other Katari scripting features.

Example of an exported structure
```json
    "Player": {
      "id": "Player",
      "functions": [
        {"name": "playSound", "suspend": false, "returns": "Unit", "params": [{"name": "sound", "type": "String", "optional": false}, {"name": "volume", "type": "Double", "optional": true}, {"name": "pitch", "type": "Double", "optional": true}]},
        {"name": "give", "suspend": false, "returns": "Unit", "params": [{"name": "item", "type": "String", "optional": false}, {"name": "count", "type": "Int", "optional": true}]},
        {"name": "waitZone", "suspend": true, "returns": "Player", "params": [{"name": "position", "type": "Vec3", "optional": false}, {"name": "radius", "type": "Double", "optional": true}, {"name": "leave", "type": "Boolean", "optional": true}]},
        {"name": "waitKey", "suspend": true, "returns": "KatariInputSnapshot", "params": [{"name": "key", "type": "Int", "optional": false}, {"name": "action", "type": "KatariInputAction", "optional": true}]},
        {"name": "waitClick", "suspend": true, "returns": "KatariInputSnapshot", "params": [{"name": "button", "type": "Int", "optional": false}, {"name": "action", "type": "KatariInputAction", "optional": true}]},
        {"name": "waitScroll", "suspend": true, "returns": "KatariInputSnapshot", "params": []}
      ],
      "properties": [
      ]
    },
```