### PR TITLE
Обновление pack.mcmeta

### DIFF
--- a/runtime/src/main/resources/pack.mcmeta
+++ b/runtime/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "${mod_name}",
-        "pack_format": 9
+        "pack_format": 34
     }
 }


### PR DESCRIPTION
"pack_format": 9 это формат ресурсов для 1.18.2
Исправил это значение на 34 (это официальный формат ресурсов для версии 1.21.1)